### PR TITLE
Remove deploy-python-2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,6 @@ workflows:
   build_and_deploy:
     jobs:
       - build_python3
-      - deploy_python2:
-          requires:
-            - build_python3
-          filters:
-            branches:
-              only: master
       - deploy_python3:
           requires:
             - build_python3


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

*  Changement mineur.
* Détails :
  - Vire le deploy python 2
