### PR TITLE
Use ConfigParser in place of SafeConfigParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.1 [#XX](https://github.com/openfisca/openfisca-cote-d-ivoire/pull/XX)
+
+* Amélioration technique.
+  - Utilise ConfigParser au lieu de SafeConfigParser (fix #20)
+
 ## 0.9.0 [#27](https://github.com/openfisca/openfisca-cote-d-ivoire/pull/27)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.1 [#XX](https://github.com/openfisca/openfisca-cote-d-ivoire/pull/XX)
+## 0.9.1 [#29](https://github.com/openfisca/openfisca-cote-d-ivoire/pull/29)
 
 * Amélioration technique.
   - Utilise ConfigParser au lieu de SafeConfigParser (fix #20)

--- a/openfisca_cote_d_ivoire/input_data_builder.py
+++ b/openfisca_cote_d_ivoire/input_data_builder.py
@@ -14,7 +14,7 @@ from openfisca_core import periods
 log = logging.getLogger(__file__)
 
 
-config_parser = configparser.SafeConfigParser()
+config_parser = configparser.ConfigParser()
 config_parser.read(os.path.join(config_files_directory, 'raw_data.ini'))
 data_is_available = config_parser.has_section("cote_d_ivoire")
 if not data_is_available:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-COTE_D_IVOIRE',
-    version='0.9.0',
+    version='0.9.1',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for COTE_D_IVOIRE',


### PR DESCRIPTION
 Amélioration technique.
  - Utilise ConfigParser au lieu de SafeConfigParser (fix #20)
